### PR TITLE
bumped fog version for us-west-2 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    dew (0.3.0)
+    dew (0.4.1)
       clamp (~> 0.2.3)
-      fog (~> 1.0.0)
+      fog (~> 1.1.2)
       gofer (~> 0.2.5)
       highline (~> 1.6.2)
       inform (~> 0.0.5)
@@ -23,18 +23,18 @@ GEM
       json (>= 1.4.6)
       term-ansicolor (>= 1.0.5)
     diff-lcs (1.1.3)
-    excon (0.7.6)
+    excon (0.9.5)
     flay (1.4.3)
       ruby_parser (~> 2.0)
       sexp_processor (~> 3.0)
-    fog (1.0.0)
+    fog (1.1.2)
       builder
-      excon (~> 0.7.3)
+      excon (~> 0.9.0)
       formatador (~> 0.2.0)
       mime-types
       multi_json (~> 1.0.3)
       net-scp (~> 1.0.4)
-      net-ssh (~> 2.1.4)
+      net-ssh (>= 2.1.3)
       nokogiri (~> 1.5.0)
       ruby-hmac
     formatador (0.2.1)
@@ -46,15 +46,15 @@ GEM
     gofer (0.2.5)
       net-scp (>= 1.0.4)
       net-ssh (>= 2.0.23)
-    highline (1.6.2)
+    highline (1.6.11)
     inform (0.0.5)
     json (1.6.1)
     libxml-ruby (2.1.2)
-    mime-types (1.17.1)
-    multi_json (1.0.3)
+    mime-types (1.17.2)
+    multi_json (1.0.4)
     net-scp (1.0.4)
       net-ssh (>= 1.99.1)
-    net-ssh (2.1.4)
+    net-ssh (2.3.0)
     nokogiri (1.5.0)
     opensrs (0.3.2)
       libxml-ruby (~> 2.1.2)
@@ -82,7 +82,7 @@ GEM
       rack-protection (~> 1.1, >= 1.1.2)
       tilt (~> 1.3, >= 1.3.3)
     term-ansicolor (1.0.7)
-    terminal-table (1.4.3)
+    terminal-table (1.4.4)
     tilt (1.3.3)
 
 PLATFORMS

--- a/dew.gemspec
+++ b/dew.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("inform", "~> 0.0.5")
   s.add_runtime_dependency("clamp", "~> 0.2.3")
-  s.add_runtime_dependency("fog", "~> 1.0.0")
+  s.add_runtime_dependency("fog", "~> 1.1.2")
   s.add_runtime_dependency("gofer", "~> 0.2.5")
   s.add_runtime_dependency("highline", "~> 1.6.2")
   s.add_runtime_dependency("terminal-table", "~> 1.4.3")

--- a/lib/dew/version.rb
+++ b/lib/dew/version.rb
@@ -1,3 +1,3 @@
 module Dew
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
Needed newer version of fog.

Bumped gem version to 0.4.1
